### PR TITLE
 Add ssm parameter inside rds module

### DIFF
--- a/terraform/_provider.tf
+++ b/terraform/_provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-southeast-2"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,3 @@
+module "rds" {
+  source = "./modules/rds"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,4 @@
 module "rds" {
   source = "./modules/rds"
 }
+

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,32 @@
+
+resource "aws_ssm_parameter" "db_host" {
+  name        = "WORDPRESS_DB_HOST"
+  description = "Database Host Paramater"
+  type        = "SecureString"
+  value       = ""
+  overwrite   = true
+}
+
+resource "aws_ssm_parameter" "db_name" {
+  name        = "WORDPRESS_DB_NAME"
+  description = "Database Name Paramater"
+  type        = "SecureString"
+  value       = ""
+  overwrite   = true
+}
+
+resource "aws_ssm_parameter" "db_user" {
+  name        = "WORDPRESS_DB_USER"
+  description = "Database User Paramater"
+  type        = "SecureString"
+  value       = ""
+  overwrite   = true
+}
+
+resource "aws_ssm_parameter" "db_password" {
+  name        = "WORDPRESS_DB_PASSWORD"
+  description = "Database Password Paramater"
+  type        = "SecureString"
+  value       = ""
+  overwrite   = true
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -3,7 +3,7 @@ resource "aws_ssm_parameter" "db_host" {
   name        = "WORDPRESS_DB_HOST"
   description = "Database Host Paramater"
   type        = "SecureString"
-  value       = ""
+  value       = "  " # This to be replaced by RDS Host Endpoint
   overwrite   = true
 }
 
@@ -11,22 +11,41 @@ resource "aws_ssm_parameter" "db_name" {
   name        = "WORDPRESS_DB_NAME"
   description = "Database Name Paramater"
   type        = "SecureString"
-  value       = ""
-  overwrite   = true
+  value       = var.db_name
+  overwrite   = false
+
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
 }
 
 resource "aws_ssm_parameter" "db_user" {
   name        = "WORDPRESS_DB_USER"
   description = "Database User Paramater"
   type        = "SecureString"
-  value       = ""
-  overwrite   = true
+  value       = var.db_user
+  overwrite   = false
+
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
 }
 
 resource "aws_ssm_parameter" "db_password" {
   name        = "WORDPRESS_DB_PASSWORD"
   description = "Database Password Paramater"
   type        = "SecureString"
-  value       = ""
-  overwrite   = true
+  value       = var.db_password
+  overwrite   = false
+
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
 }
+

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,14 @@
+variable "db_name" {
+  type    = string
+  default = "  "
+}
+
+variable "db_user" {
+  type    = string
+  default = "  "
+}
+
+variable "db_password" {
+  type    = string
+  default = "  "
+}


### PR DESCRIPTION
**Objectives**:

Generate 4 empty keys on SSM Parameter Store to be used for wordpress secrets.

- /wordpress/WORDPRESS_DB_HOST
- /wordpress/WORDPRESS_DB_USER
- /wordpress/WORDPRESS_DB_PASSWORD
- /wordpress/WORDPRESS_DB_NAME

**Acceptance Criteria:**

- [x] Parameters are of type SecureString either with default or custom SSM Key
- [x] Terraform code for creating ssm parameters
- [x] Value of parameters to be manually changed through the console (terraform leave logging trace of the values)

**Files added:**

1. terraform/_provider.tf
2. terraform/main.tf
3. terraform/modules/rds/main.tf
4. terraform/modules/rds/output.tf
5. terraform/modules/rds/variables.tf