### PR TITLE
ECR Repository

### DIFF
--- a/terraform/modules/container_registry/README.md
+++ b/terraform/modules/container_registry/README.md
@@ -1,0 +1,95 @@
+# Module Objective
+
+This module will create the ECR repository registry for the docker wordpress image.
+
+> The default repository name is \*\*devops-wordpress\*\*. It can be replaced with the input variable `repository_name`.
+
+## Module Usage
+
+```hcl
+module "container_registry" {
+    source = "./modules/container_registry"
+    repository_name = "devops-wordpress"
+}
+```
+
+Example of \*\*`outputs.tf`** file:
+
+```hcl
+output "registry" {
+    value = module.container_registry.ecr_repository
+}
+
+```
+
+Where the value will contains the object:
+
+```hcl
+registry = {
+    "arn" = "arn:aws:ecr:ap-southeast-2:097922957316:repository/devops-wordpress"
+    "id" = "devops-wordpress"
+    "name" = "devops-wordpress"
+    "repository_url" = "097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress"
+}
+```
+
+## Connecting to ECR
+
+The ECR is private so it is necessary to generate an authentication token to provide to the docker client.  
+We can do that with the command below:
+
+```bash
+aws ecr get-login-password \
+	--region ${AWS_REGION} \
+	| docker login \
+	--username AWS \
+	--password-stdin ${DOCKER_REGISTRY_URL}
+```
+
+The first command `aws ecr get-login-password` will use the default aws profile to get the authentication token.  
+The output of this command will be passed in to `docker login` command.
+
+## Pulling and Pushing Images
+
+Once that we connect to the ECR, now we can push/pull images as we normally do using the docker client commands: `docker push` and `docker pull`.
+
+For the docker push to work, the image should be tagged with the repository path like:
+
+```bash
+docker tag devops-wordpress:latest 097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress:f5bcbb2
+```
+
+* Where `f5bcbb2` is the commit sha
+* The number `097922957316` is the aws account id where the image from the ECR repository.
+
+### To push the image
+
+```bash
+docker push 097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress:f5bcbb2
+```
+
+### To pull the image
+
+```bash
+docker pull 097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress:f5bcbb2
+```
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| common\_tags | common tags which will be merged with all resources created. | `map(string)` | <pre>{<br>  "deployed_by": "terraform",<br>  "devops_academy": "project1"<br>}</pre> | no |
+| repository\_name | the name of the ECR repository to be created. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ecr\_repository | attributes of the ecr repository created. |
+

--- a/terraform/modules/container_registry/README.md
+++ b/terraform/modules/container_registry/README.md
@@ -74,22 +74,42 @@ docker push 097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress:f
 docker pull 097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress:f5bcbb2
 ```
 
-## Providers
+## Required Inputs
 
-| Name | Version |
-|------|---------|
-| aws | n/a |
+No required input.
 
-## Inputs
+## Optional Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| common\_tags | common tags which will be merged with all resources created. | `map(string)` | <pre>{<br>  "deployed_by": "terraform",<br>  "devops_academy": "project1"<br>}</pre> | no |
-| repository\_name | the name of the ECR repository to be created. | `string` | n/a | yes |
+The following input variables are optional (have default values):
+
+### common\_tags
+
+Description: common tags which will be merged with all resources created.
+
+Type: `map(string)`
+
+Default:
+
+```json
+{
+  "deployed_by": "terraform",
+  "devops_academy": "project1"
+}
+```
+
+### repository\_name
+
+Description: the name of the ECR repository to be created.
+
+Type: `string`
+
+Default: `"devops-wordpress"`
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| ecr\_repository | attributes of the ecr repository created. |
+The following outputs are exported:
+
+### ecr\_repository
+
+Description: attributes of the ecr repository created.
 

--- a/terraform/modules/container_registry/doc.md
+++ b/terraform/modules/container_registry/doc.md
@@ -1,0 +1,75 @@
+# Module Objective
+
+This module will create the ECR repository registry for the docker wordpress image.
+
+> The default repository name is **devops-wordpress**. It can be replaced with the input variable `repository_name`.
+
+## Module Usage
+
+```hcl
+module "container_registry" {
+    source = "./modules/container_registry"
+    repository_name = "devops-wordpress"
+}
+```
+
+Example of **`outputs.tf`** file:
+
+```hcl
+output "registry" {
+    value = module.container_registry.ecr_repository
+}
+
+```
+
+Where the value will contains the object:
+
+```hcl
+registry = {
+    "arn" = "arn:aws:ecr:ap-southeast-2:097922957316:repository/devops-wordpress"
+    "id" = "devops-wordpress"
+    "name" = "devops-wordpress"
+    "repository_url" = "097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress"
+}
+```
+
+## Connecting to ECR
+
+The ECR is private so it is necessary to generate an authentication token to provide to the docker client.
+We can do that with the command below:
+
+```bash
+aws ecr get-login-password \
+	--region ${AWS_REGION} \
+	| docker login \
+	--username AWS \
+	--password-stdin ${DOCKER_REGISTRY_URL}
+```
+
+The first command `aws ecr get-login-password` will use the default aws profile to get the authentication token.
+The output of this command will be passed in to `docker login` command.
+
+## Pulling and Pushing Images
+
+Once that we connect to the ECR, now we can push/pull images as we normally do using the docker client commands: `docker push` and `docker pull`.
+
+For the docker push to work, the image should be tagged with the repository path like:
+
+```bash
+docker tag devops-wordpress:latest 097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress:f5bcbb2
+```
+
+* Where `f5bcbb2` is the commit sha
+* The number `097922957316` is the aws account id where the image from the ECR repository.
+
+### To push the image
+
+```bash
+docker push 097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress:f5bcbb2
+```
+
+### To pull the image
+
+```bash
+docker pull 097922957316.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wordpress:f5bcbb2
+```

--- a/terraform/modules/container_registry/main.tf
+++ b/terraform/modules/container_registry/main.tf
@@ -1,0 +1,11 @@
+resource "aws_ecr_repository" "repo" {
+  name                 = var.repository_name
+  image_tag_mutability = "MUTABLE"
+  tags = merge(var.common_tags, {
+    Name = "devops-${var.repository_name}"
+  })
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/terraform/modules/container_registry/outputs.tf
+++ b/terraform/modules/container_registry/outputs.tf
@@ -1,0 +1,9 @@
+output "ecr_repository" {
+  description = "attributes of the ecr repository created."
+  value = {
+    id             = aws_ecr_repository.repo.id
+    arn            = aws_ecr_repository.repo.arn
+    name           = aws_ecr_repository.repo.name
+    repository_url = aws_ecr_repository.repo.repository_url
+  }
+}

--- a/terraform/modules/container_registry/variables.tf
+++ b/terraform/modules/container_registry/variables.tf
@@ -1,0 +1,13 @@
+variable "common_tags" {
+  description = "common tags which will be merged with all resources created."
+  type        = map(string)
+  default = {
+    devops_academy = "project1"
+    deployed_by    = "terraform"
+  }
+}
+
+variable "repository_name" {
+  description = "the name of the ECR repository to be created."
+  type        = string
+}

--- a/terraform/modules/container_registry/variables.tf
+++ b/terraform/modules/container_registry/variables.tf
@@ -10,4 +10,5 @@ variable "common_tags" {
 variable "repository_name" {
   description = "the name of the ECR repository to be created."
   type        = string
+  default     = "devops-wordpress"
 }


### PR DESCRIPTION
## Work tracking list

- [x]  Create a private ECR repository for hosting wordpress container image
- [x] The ECR Repository is not public
- [x] Can push a container to that Registry
- [x] Can pull images from ECR from EC2 instances running on my VPC
- [x] The README contains the name of the repo and instructions to push/pull images from the repository

---

The file `doc.md` is used as header content for the README.md. It is how we can inject some content at the final document file generated by `terraform-docs`.