### PR TITLE
add script to generate the documents for terraform modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/*/.terraform
 .terraform*
 **/*.tfstate
+!.terraform-docs.yml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+docs-terraform: $(TERRAFORM_MODULES)
+	@scripts/update-terraform-docs.sh
+.PHONY:docs-terraform

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,38 @@
+# Introduction
+
+## docs-terraform
+
+Usage:
+
+Go to the root directory and run:
+
+```bash
+make docs-terraform
+```
+
+This script will generate the terraform module documentation based on your input/output variables.
+
+It uses [terraform-docs](https://github.com/terraform-docs/terraform-docs) to read `.tf` files and generate the document.
+
+_The script use the docker image with the bin installed so you don't need to install nothing in your machine._
+
+> This script will loop though `terraform/modules` directory and **create/replace** the file a `README.md` for every module.
+
+You can customize the output with a config file. Follow [this link](https://github.com/terraform-docs/terraform-docs/blob/master/docs/CONFIG_FILE.md) for more details.
+
+Here a sample file `.terraform-docs.yml` file:
+
+```yaml
+formatter: markdown document
+header-from: doc.md
+
+sections:
+  hide:
+    - providers
+    - requirements
+```
+
+This script will:
+- format the document as `markdown document`
+- inject the content of `doc.md` into `README.md`
+- hide the sections: `providers` and `requirements`

--- a/scripts/update-terraform-docs.sh
+++ b/scripts/update-terraform-docs.sh
@@ -1,0 +1,13 @@
+TERRAFORM_DOCS_VERSION=0.10.0-rc.1
+
+for d in $(ls -1 terraform/modules);
+do
+
+docker run \
+    -v $(pwd)/terraform/modules/$d:/module \
+    quay.io/terraform-docs/terraform-docs:$TERRAFORM_DOCS_VERSION markdown document /module > terraform/modules/$d/README.md
+
+if [ $? -eq 0 ] ; then
+    git add "./terraform/modules/$d/README.md"
+fi
+done


### PR DESCRIPTION
This small script will generate documents for the terraform modules using terraform-docs.

It is using the docker image version of the terraform-docs CLI so you don't need to install anything in your system. It just might take a little bit longer for the first time.

I also added a quick doc to how to use the scripts and how it can be customised.

Quick summary to run the script:

1. the modules should be placed at `terraform/modules/<your module here>` (it might change)
2. to run the script you should go to the root directory and run `make docs-terraform`

If you like to add a extra content, please refer to the `docs/scripts.md`.