### PR TITLE
add the module to create the load balancer

### DIFF
--- a/terraform/modules/load_balancer/.terraform-docs.yml
+++ b/terraform/modules/load_balancer/.terraform-docs.yml
@@ -1,0 +1,7 @@
+formatter: markdown document
+header-from: doc.md
+
+sections:
+  hide:
+    - providers
+    - requirements

--- a/terraform/modules/load_balancer/README.md
+++ b/terraform/modules/load_balancer/README.md
@@ -1,0 +1,66 @@
+# Module Objective
+
+This module abstract the creation of an Application Load Balancer, Target Groups, Listeners and Security Groups.
+
+Ideally, someone who would use the `target_group_arn` output from this module to attatch to an Autoscalling Group using
+`aws_autoscalling_attachment` resource and passing the `autoscalling_group_name`. Please refer for the example below:
+
+```hcl
+resource "aws_autoscaling_attachment" "this" {
+    autoscaling_group_name = aws_autoscaling_group.devops.id
+    alb_target_group_arn = module.load_balancer.target_group_arn
+}
+```
+
+> This module doens't created the ASG.
+
+The port which the Load Balancer will listen to request can be modified with the input variable `https_enabled`. The default value is true (https enabled), but for testing purposes, it can be disabled.
+
+## Required Inputs
+
+The following input variables are required:
+
+### lb\_subnets
+
+Description: the list of subnets / availability zones for the load balancer
+
+Type: `list(string)`
+
+### vpc\_id
+
+Description: the vpc id for the load balancer
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### https\_enabled
+
+Description: enable/disable https (port 443) in the load balancer's security group
+
+Type: `bool`
+
+Default: `true`
+
+### project
+
+Description: the project name to add as preffix for some resources
+
+Type: `string`
+
+Default: `"devops-wordpress"`
+
+## Outputs
+
+The following outputs are exported:
+
+### load\_balancer
+
+Description: the details of the load balancer created { arn, arn\_suffix, dns\_name, zone\_id }
+
+### target\_group\_arn
+
+Description: the target group arn linked of the load balancer's listener
+

--- a/terraform/modules/load_balancer/doc.md
+++ b/terraform/modules/load_balancer/doc.md
@@ -1,0 +1,17 @@
+# Module Objective
+
+This module abstract the creation of an Application Load Balancer, Target Groups, Listeners and Security Groups.
+
+Ideally, someone who would use the `target_group_arn` output from this module to attach to an Autoscalling Group using
+`aws_autoscalling_attachment` resource and passing the `autoscalling_group_name`. Please refer for the example below:
+
+```hcl
+resource "aws_autoscaling_attachment" "this" {
+    autoscaling_group_name = aws_autoscaling_group.devops.id
+    alb_target_group_arn = module.load_balancer.target_group_arn
+}
+```
+
+> This module doens't created the ASG.
+
+The port which the Load Balancer will listen to request can be modified with the input variable `https_enabled`. The default value is true (https enabled), but for testing purposes, it can be disabled.

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -1,0 +1,60 @@
+locals {
+  targetPort     = var.https_enabled ? 443 : 80
+  targetProtocol = var.https_enabled ? "HTTPS" : "HTTP"
+}
+
+resource "aws_lb" "this" {
+  name               = "${var.project}-lb"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = var.lb_subnets
+
+  security_groups = [
+    aws_security_group.allow_web.id
+  ]
+
+  tags = {
+    Name = "${var.project}-lb"
+  }
+}
+
+resource "aws_lb_target_group" "this" {
+  name     = "${var.project}-lb-tg"
+  port     = local.targetPort
+  protocol = local.targetProtocol
+  vpc_id   = var.vpc_id
+}
+
+resource "aws_lb_listener" "this" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = local.targetPort
+  protocol          = local.targetProtocol
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+resource "aws_security_group" "allow_web" {
+  name   = "${var.project} - allow web access"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = local.targetPort
+    to_port     = local.targetPort
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # TODO: restrict the egress, probably it would only need access to EC2 instances SG
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project}-allow-web-access-sg"
+  }
+}

--- a/terraform/modules/load_balancer/outputs.tf
+++ b/terraform/modules/load_balancer/outputs.tf
@@ -1,0 +1,14 @@
+output "target_group_arn" {
+  description = "the target group arn linked of the load balancer's listener"
+  value       = aws_lb_target_group.this.arn
+}
+
+output "load_balancer" {
+  description = "the details of the load balancer created { arn, arn_suffix, dns_name, zone_id }"
+  value = {
+    arn        = aws_lb.this.arn
+    arn_suffix = aws_lb.this.arn_suffix
+    dns_name   = aws_lb.this.dns_name
+    zone_id    = aws_lb.this.zone_id
+  }
+}

--- a/terraform/modules/load_balancer/variables.tf
+++ b/terraform/modules/load_balancer/variables.tf
@@ -1,0 +1,22 @@
+variable "vpc_id" {
+  description = "the vpc id for the load balancer"
+  type        = string
+}
+
+variable "lb_subnets" {
+  description = "the list of subnets / availability zones for the load balancer"
+  type        = list(string)
+}
+
+variable "https_enabled" {
+  description = "enable/disable https (port 443) in the load balancer's security group"
+  type        = bool
+  default     = true
+}
+
+variable "project" {
+  description = "the project name to add as preffix for some resources"
+  type        = string
+  default     = "devops-wordpress"
+}
+


### PR DESCRIPTION
Module Objectives:

* Create the load balancer which will forward HTTPS request to ECS containers.
* During test stages, the HTTP could be enabled via variable `https_enabled = false`.

Task: #9 

Refer to `README.md` for the required inputs for this module and its output.

---

**The egress rules for the SG is relaxed during the development stage, it will be updated to allow egress only to the SG linked to the EC2 instances**