### PR TITLE
add main.tf file to call all submodules

### DIFF
--- a/terraform/_provider.tf
+++ b/terraform/_provider.tf
@@ -1,3 +1,4 @@
 provider "aws" {
-  region = "ap-southeast-2"
+  version = "~> 2.0"
+  region  = var.aws_region
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,13 +19,13 @@ module "rds-aurora-database" {
   private_subnets = module.vpc.private_subnets[*].id
 }
 
-# module "load_balancer" {
-#   source        = "./modules/load_balancer"
-#   project       = var.project
-#   vpc_id        = module.vpc.vpc_id
-#   lb_subnets    = module.vpc.public_subnets[*].id
-#   https_enabled = var.https_enabled
-# }
+module "load_balancer" {
+  source        = "./modules/load_balancer"
+  project       = var.project
+  vpc_id        = module.vpc.vpc_id
+  lb_subnets    = module.vpc.public_subnets[*].id
+  https_enabled = var.https_enabled
+}
 
 module "container_registry" {
   source = "./modules/container_registry"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,44 @@
+module "vpc" {
+  source       = "./modules/VPC-network"
+  project-name = var.project
+  vpcCIDR      = var.vpcCIDR
+  deploy_nat   = var.deploy_nat
+}
+
 module "rds" {
   source = "./modules/rds"
 }
 
+module "rds-aurora-database" {
+  source  = "./modules/rds-aurora-database"
+  project = var.project
+  vpc = {
+    id         = module.vpc.vpc_id
+    cidr_block = var.vpcCIDR
+  }
+  private_subnets = module.vpc.private_subnets[*].id
+}
+
+# module "load_balancer" {
+#   source        = "./modules/load_balancer"
+#   project       = var.project
+#   vpc_id        = module.vpc.vpc_id
+#   lb_subnets    = module.vpc.public_subnets[*].id
+#   https_enabled = var.https_enabled
+# }
+
+module "container_registry" {
+  source = "./modules/container_registry"
+}
+
+# module "EFS_MODULE" {
+#   source = "MODULE_PATH"
+# }
+
+# module "ECS_CLUSTER_MODULE" {
+#   source = "MODULE_PATH"
+# }
+
+# module "ECS_SERVICE_MODULE" {
+#   source = "MODULE_PATH"
+# }

--- a/terraform/main.tfvars
+++ b/terraform/main.tfvars
@@ -1,0 +1,3 @@
+project       = "devops-wordpress"
+deploy_nat    = false
+https_enabled = false

--- a/terraform/modules/VPC-network/main.tf
+++ b/terraform/modules/VPC-network/main.tf
@@ -88,6 +88,8 @@ resource "aws_eip" "NAT-EIP" {
 
 # NAT Gateway
 resource "aws_nat_gateway" "NAT-GW" {
+  count = var.deploy_nat ? 1 : 0	
+
   allocation_id = aws_eip.NAT-EIP.id
   subnet_id     = aws_subnet.subnet-public-1.id
   depends_on = [aws_internet_gateway.IGW]

--- a/terraform/modules/VPC-network/outputs.tf
+++ b/terraform/modules/VPC-network/outputs.tf
@@ -1,0 +1,38 @@
+
+output "vpc_id" {
+  value = aws_vpc.vpc.id
+}
+
+output "public_subnets" {
+  value = [
+    {
+      id                = aws_subnet.subnet-public-1.id
+      availability_zone = aws_subnet.subnet-public-1.availability_zone
+      cidr_block        = aws_subnet.subnet-public-1.cidr_block
+      arn               = aws_subnet.subnet-public-1.arn
+    },
+    {
+      id                = aws_subnet.subnet-public-2.id
+      availability_zone = aws_subnet.subnet-public-2.availability_zone
+      cidr_block        = aws_subnet.subnet-public-2.cidr_block
+      arn               = aws_subnet.subnet-public-2.arn
+    }
+  ]
+}
+
+output "private_subnets" {
+  value = [
+    {
+      id                = aws_subnet.subnet-private-1.id
+      availability_zone = aws_subnet.subnet-private-1.availability_zone
+      cidr_block        = aws_subnet.subnet-private-1.cidr_block
+      arn               = aws_subnet.subnet-private-1.arn
+    },
+    {
+      id                = aws_subnet.subnet-private-2.id
+      availability_zone = aws_subnet.subnet-private-2.availability_zone
+      cidr_block        = aws_subnet.subnet-private-2.cidr_block
+      arn               = aws_subnet.subnet-private-2.arn
+    }
+  ]
+}

--- a/terraform/modules/VPC-network/route-table.tf
+++ b/terraform/modules/VPC-network/route-table.tf
@@ -13,14 +13,18 @@ resource "aws_route_table" "route-table-PUB" {
 # private
 resource "aws_route_table" "route-table-PRI" {
     vpc_id = aws_vpc.vpc.id
-    route {
-      cidr_block = "0.0.0.0/0"
-      gateway_id = aws_nat_gateway.NAT-GW.id
-    }
+
     tags = {
 	Name = "${var.project-name}-route-table-PRI"
 	}
 		
+}
+
+resource "aws_route" "private-nat-route" {
+    count = length(aws_nat_gateway.NAT-GW)
+    route_table_id = aws_route_table.route-table-PRI.id
+    destination_cidr_block = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.NAT-GW[count.index].id
 }
 
 # route table associations

--- a/terraform/modules/VPC-network/variables.tf
+++ b/terraform/modules/VPC-network/variables.tf
@@ -34,3 +34,8 @@ variable "map_public_ip2" {
     type    = bool
     default = true
 }
+
+variable "deploy_nat" {
+    type = bool
+    default = true
+}

--- a/terraform/modules/rds-aurora-database/main.tf
+++ b/terraform/modules/rds-aurora-database/main.tf
@@ -1,64 +1,26 @@
-// setting the provider
-provider "aws" {
-  version = "~> 2.0"
-  region  = "ap-southeast-2"
-}
-
-
-// defining custom vpc
-// TODO: utilize the project's main VPC
-resource "aws_vpc" "temp_custom_vpc" {
-  cidr_block = "192.168.0.0/16"
-  tags = {
-    "Name" = "Terraform - temp_custom_vpc"
-  }
-}
-
-//defining custom subnet
-// TODO: utilize the project's subnetsh
-resource "aws_subnet" "temp_da_rds_subnet" {
-  vpc_id     = aws_vpc.temp_custom_vpc.id
-  cidr_block = "192.168.51.0/24"
-  availability_zone = "ap-southeast-2a"
-
-  tags = {
-    Name = "Terraform - temp_da_rds_subnet"
-  }
-}
-
-resource "aws_subnet" "temp_da_rds_subnet2" {
-  vpc_id     = aws_vpc.temp_custom_vpc.id
-  cidr_block = "192.168.52.0/24"
-  availability_zone = "ap-southeast-2b"
-
-  tags = {
-    Name = "Terraform - temp_da_rds_subnet2"
-  }
-}
-
 //defining custom subnet for the database
 resource "aws_db_subnet_group" "da_db_subnet_group" {
-  name       = "aws_db_subnet_group_da_sb_subnet"
-  subnet_ids = [aws_subnet.temp_da_rds_subnet.id, aws_subnet.temp_da_rds_subnet2.id]
+  name       = "${var.project}-db-subnet-group"
+  subnet_ids = var.private_subnets
 
   tags = {
-    Name = "Terraform - My DB subnet group"
+    Name = "${var.project}-DB subnet group"
   }
 }
 
 //defining security group
 // TODO: update rules accordingly
 resource "aws_security_group" "da_rds_security_group" {
-  name        = "access to mysql"
+  name        = "${var.project} access to mysql"
   description = "Allow inbound traffic on port 3306"
-  vpc_id      = aws_vpc.temp_custom_vpc.id
+  vpc_id      = var.vpc.id
 
   ingress {
     description = "Aurora mysql Inbound"
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = [aws_vpc.temp_custom_vpc.cidr_block]
+    cidr_blocks = [var.vpc.cidr_block]
   }
 
   egress {
@@ -69,7 +31,7 @@ resource "aws_security_group" "da_rds_security_group" {
   }
 
   tags = {
-    "Name" = "Terraform security group"
+    "Name" = "${var.project}-aurora-db-sg"
   }
 
 }

--- a/terraform/modules/rds-aurora-database/variables.tf
+++ b/terraform/modules/rds-aurora-database/variables.tf
@@ -1,0 +1,19 @@
+variable "vpc" {
+  description = "the vpc id for the aurora database"
+  type        = object({
+      id = string
+      cidr_block = string
+  })
+}
+
+variable "private_subnets" {
+  description = "the list of subnets / availability zones for the rds database"
+  type        = list(string)
+}
+
+
+variable "project" {
+  description = "the project name to add as preffix for some resources"
+  type        = string
+  default     = "devops-wordpress"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc-module" {
+  value = module.vpc
+}
+
+# output "lb-module" {
+#   value = module.load_balancer
+# }
+
+output "ecr-module" {
+  value = module.container_registry
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  type    = string
+  default = "ap-southeast-2"
+}
+
+variable "project" {
+  description = "the name of the project"
+  type        = string
+}
+
+variable "vpcCIDR" {
+  description = "VPC network"
+  type        = string
+  default     = "192.168.0.0/16"
+}
+
+variable "deploy_nat" {
+  description = "if true, the Network Gateway will be deployed for private subnets"
+  type        = bool
+  default     = true
+}
+
+variable "https_enabled" {
+  description = "enable/disable https (port 443) in the load balancer's security group"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
As promised, here is the main terraform configuration to call all submodules.

I added some placeholder modules in the **`main.tf`** so you should be able to uncomment those lines when your module is done.

## Some changes in other modules

- In @feernandobraga RDS module:
  - Removed the extra vpc, subnets resources. **if you have current work in this module, ensure to destroy everything in AWS and rebase your branch**
  - Add a **`project`** variable to be used as suffix for some resources (easy to identify and you can create something like **`devops-wordpress-fernando`** for you own resources / tests)

<br />

- In @zarajoy VPC module:
  - Add **`output.tf`** with vpc, subnets details to be used in the other modules.
  - To avoid deploying NAT (extra charge) and forget to destroy it, I added a flag **`deploy_nat`** so you can control if you want/need to deploy the nat or not. By default, it will deploy since it is the requirement for this project.

<br />

- For the load-balancer module #25, there is flag **`https_enabled`** to switch between http - https. If https is enabled, the load_balancer module will fail to deploy due to validate SSL certificate error. So, for our test purpose, keep this flag disabled.

## Usage

For now, just use the terraform CLI as normal you do with your configuration in the **`tfvars`** file.