### PR TITLE
mfreitassm/efs

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,9 +31,16 @@ module "container_registry" {
   source = "./modules/container_registry"
 }
 
-# module "EFS_MODULE" {
-#   source = "MODULE_PATH"
-# }
+ module "efs" {
+  source = "./modules/efs"
+  project_name = var.project
+  vpc = {
+    id                  = module.vpc.vpc_id
+    private_subnets_ids = module.vpc.private_subnets[*].id
+  }
+  cidr_block = var.vpcCIDR
+  ecs_sg_id = module.ECS.ecs-access-security-group.id
+}
 
 # module "ECS_CLUSTER_MODULE" {
 #   source = "MODULE_PATH"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,7 +31,7 @@ module "container_registry" {
   source = "./modules/container_registry"
 }
 
- module "efs" {
+ module "EFS" {
   source = "./modules/efs"
   project_name = var.project
   vpc = {
@@ -39,7 +39,7 @@ module "container_registry" {
     private_subnets_ids = module.vpc.private_subnets[*].id
   }
   cidr_block = var.vpcCIDR
-  ecs_sg_id = module.ECS.ecs-access-security-group.id
+  ecs_sg_id = module.ECS_CLUSTER_MODULE.ecs-access-security-group
 }
 
 module "ECS_CLUSTER_MODULE" {

--- a/terraform/modules/efs/README.md
+++ b/terraform/modules/efs/README.md
@@ -1,0 +1,19 @@
+Objectives:
+
+Use vpc from network stack
+Available in both AZs
+Security group allowing only ECS instances to access it
+No lifecycle policy
+Throughput mode bursting
+Performance mode general purpose
+No need for encryption
+No need for IAM authentication
+Add one access point:
+Name wordpress
+Path /wordpress
+
+Acceptance Criteria:
+
+EFS is available in at least two AZ
+I can mount efs volume on an ec2 instance running on private subnet following instructions https://docs.aws.amazon.com/efs/latest/ug/mounting-fs.html
+I CAN'T mount efs volume from instance on public subnet

--- a/terraform/modules/efs/main.tf
+++ b/terraform/modules/efs/main.tf
@@ -1,0 +1,47 @@
+resource "aws_efs_file_system" "efs_file" {
+  creation_token = "my-efs"
+
+  tags = {
+    Name = "wordpress"
+  }
+}
+
+resource "aws_efs_mount_target" "alpha" {
+
+  count = length(var.subnet_ids)
+
+  file_system_id = "${aws_efs_file_system.foo.id}"
+  subnet_id      = var.subnet_ids[count.index]
+}
+
+resource "aws_vpc" "foo" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "alpha" {
+  vpc_id            = "${aws_vpc.foo.id}"
+  availability_zone = "us-west-2a"
+  cidr_block        = "10.0.1.0/24"
+}
+
+resource "aws_security_group" "efs_sg" {
+  description = "allows access to the EFS"
+
+  vpc_id = var.vpc_id
+  name   = "efs-sg"
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 2049
+    to_port         = 2049
+    security_groups = [var.efs_sg.sg_id]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [var.cidr_vpc]
+  }
+}

--- a/terraform/modules/efs/output.tf
+++ b/terraform/modules/efs/output.tf
@@ -1,0 +1,6 @@
+output "efs_id" {
+  value = aws_efs_file_system.efs_file.id
+}
+output "efs_dns_name" {
+  value = aws_efs_file_system.efs_file.dns_name
+}

--- a/terraform/modules/efs/variables.tf
+++ b/terraform/modules/efs/variables.tf
@@ -1,10 +1,21 @@
-variable "vpc_id" {
-  description = "VPC ID"
-  type        = string
-
+variable "project_name" {
+  type = string
 }
 
-variable "sg_id" {
-  description = "Securtity-Group ID"
+variable "vpc" {
+  description = "VPC for the EFS"
+  type = object({
+    id                  = string
+    private_subnets_ids = list(string)
+
+  })
+}
+variable "cidr_block" {
+  description = "cidr_block for the EFS"
+  type          = string
+}
+
+variable "ecs_sg_id" {
+  description = "Securtity-Group ECS ID"
   type        = string
 }

--- a/terraform/modules/efs/variables.tf
+++ b/terraform/modules/efs/variables.tf
@@ -1,0 +1,10 @@
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+
+}
+
+variable "sg_id" {
+  description = "Securtity-Group ID"
+  type        = string
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,14 +1,17 @@
 variable "db_name" {
   type    = string
+  description = "Database name"
   default = "  "
 }
 
 variable "db_user" {
   type    = string
+  description = "Database Useraname"
   default = "  "
 }
 
 variable "db_password" {
   type    = string
+  description = "Database Password"
   default = "  "
 }


### PR DESCRIPTION
Objectives:

Use vpc from network stack
Available in both AZs
Security group allowing only ECS instances to access it
No lifecycle policy
Throughput mode bursting
Performance mode general purpose
No need for encryption
No need for IAM authentication
Add one access point:
Name wordpress
Path /wordpress

Acceptance Criteria:

EFS is available in at least two AZ
I can mount efs volume on an ec2 instance running on private subnet following instructions https://docs.aws.amazon.com/efs/latest/ug/mounting-fs.html
I CAN'T mount efs volume from instance on public subnet