### PR TITLE
Project organisation, refactoring, fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,8 @@ kick-n-run:
 
 wait-lb:
 	@echo "${C_RED}Waiting until the LB is ready${C_RESET}"
-	@$(DOCKER_RUNNER) aws elbv2 wait load-balancer-available --load-balancer-arns $(shell jq ".outputs[\"lb-module\"].value.load_balancer.arn" ./terraform/terraform.tfstate)
+	@$(DOCKER_RUNNER) aws elbv2 wait load-balancer-available --load-balancer-arns $(shell $(DOCKER_RUNNER) jq -r ".outputs[\"lb-module\"].value.load_balancer.arn" ./terraform/terraform.tfstate)
 	@echo "${C_GREEN}Green is good, the LB was provisioned, but the targets might be in registering stage yet.${C_RESET}"
-	@echo "Open the browser at http://$(shell jq ".outputs[\"lb-module\"].value.load_balancer.dns_name" ./terraform/terraform.tfstate)"
+	@echo "\bOpen the browser at http://$(shell $(DOCKER_RUNNER) jq -r ".outputs[\"lb-module\"].value.load_balancer.dns_name" ./terraform/terraform.tfstate)"
 .PHONY:wait-lb
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ ecr-login:
 	@echo "\n === ✅ Done"
 .PHONY:ecr_login
 
+update-wp: ecr-login build-wp push-wp
+.PHONY:update-wp
+
 ga-test-env-files:
 	@if [ ! -f ".github/secrets" ]; then \
 		echo "${C_RED}must create secrets file in .github/secrets"; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
 
   aws:
     image: amazon/aws-cli:2.0.36
+    working_dir: /app
     volumes:
       - ${PWD}:/app
       - ${HOME}/.aws:/root/.aws

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,9 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - TF_IN_AUTOMATION=yes
+
+  jq:
+    image: stedolan/jq
+    working_dir: /app
+    volumes:
+      - ${PWD}:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     image: amazon/aws-cli:2.0.36
     volumes:
       - ${PWD}:/app
+      - ${HOME}/.aws:/root/.aws
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     working_dir: /terraform
     volumes:
       - ${PWD}/terraform:/terraform
+      - ${HOME}/.aws:/root/.aws
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,3 @@
-ARG WP_VERSION=5.4-php7.2-apache
+ARG WP_VERSION=5.5-php7.2-apache
 
 FROM wordpress:${WP_VERSION}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -18,10 +18,12 @@ build:
 
 push:
 	@echo "\n === 🔖 Tagging image with sha ${C_GREEN}${COMMIT_SHA}${C_RESET}"
-	@docker tag devops-wordpress:latest ${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY}:${COMMIT_SHA}
-	
+	@docker tag ${DOCKER_REPOSITORY}:latest ${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY}:${COMMIT_SHA}
+	@docker tag ${DOCKER_REPOSITORY}:latest ${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY}:latest
+
 	@echo "\n === 🚀 Pushing into repository\n"
 	docker push ${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY}:${COMMIT_SHA}
+	docker push ${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY}:latest
 	@echo "\n === ✅ Done"
 .PHONY:push
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -26,18 +26,3 @@ push:
 	docker push ${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY}:latest
 	@echo "\n === ✅ Done"
 .PHONY:push
-
-ecr-login:
-	@echo "\n === 🔐 Login to ECR docker registry: ${C_GREEN}${DOCKER_REGISTRY_URL}${C_RESET}\n"
-
-	@aws ecr get-login-password \
-		--region ${AWS_DEFAULT_REGION} \
-		| docker login \
-		--username AWS \
-		--password-stdin ${DOCKER_REGISTRY_URL}
-
-	@echo "\n === ✅ Done"
-.PHONY:ecr_login
-
-deploy: ecr-login build push
-.PHONY: deploy

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,6 +47,7 @@ module "ecs_cluster_wordpress" {
   subnet-public-1  = module.vpc.subnet-public-1
   subnet-public-2  = module.vpc.subnet-public-2
   instance_keypair = var.instance_keypair
+  desired_count = 3
 
   container_name  = module.container_registry.ecr_repository.name
   container_image = module.container_registry.ecr_repository.repository_url

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -71,9 +71,9 @@ module "ecs_cluster_wordpress" {
 
   efs_volume_configuration = {
     file_system_id          = module.efs.id
-    root_directory          = "/wordpress/data"
+    root_directory          = "/"
     transit_encryption      = "ENABLED"
-    transit_encryption_port = 2999
+    transit_encryption_port = null
   }
 
   port_mappings = var.port_mappings

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,7 +25,7 @@ module "load_balancer" {
 
 module "container_registry" {
   source          = "./modules/container_registry"
-  repository_name = "devops-wp"
+  # repository_name = "devops-wp"
 }
 
 module "efs" {

--- a/terraform/main.tfvars
+++ b/terraform/main.tfvars
@@ -1,5 +1,5 @@
 project       = "devops-wordpress"
-deploy_nat    = true
+deploy_nat    = false
 https_enabled = false
 
 port_mappings = [

--- a/terraform/main.tfvars
+++ b/terraform/main.tfvars
@@ -1,5 +1,5 @@
 project       = "devops-wordpress"
-deploy_nat    = false
+deploy_nat    = true
 https_enabled = false
 
 port_mappings = [
@@ -13,6 +13,6 @@ port_mappings = [
 mount_points = [
   {
     containerPath = "/var/www/html",
-    sourceVolume  = "da-efs-storage"
+    sourceVolume  = "efs-system-file"
   }
 ]

--- a/terraform/modules/ECS/main.tf
+++ b/terraform/modules/ECS/main.tf
@@ -195,9 +195,9 @@ locals {
     readonlyRootFilesystem = var.readonly_root_filesystem
     secrets                = var.secrets
     # mountPoints            = local.mount_points
-    portMappings           = var.port_mappings
-    memory                 = var.container_memory
-    cpu                    = var.container_cpu
+    portMappings = var.port_mappings
+    memory       = var.container_memory
+    cpu          = var.container_cpu
   }
 
   container_definition_without_null = {

--- a/terraform/modules/ECS/main.tf
+++ b/terraform/modules/ECS/main.tf
@@ -111,6 +111,7 @@ resource "aws_launch_template" "this" {
   }
   network_interfaces {
     associate_public_ip_address = true
+    delete_on_termination = true
     security_groups = [
       aws_security_group.this.id
     ]
@@ -202,9 +203,9 @@ locals {
     readonlyRootFilesystem = var.readonly_root_filesystem
     secrets                = var.secrets
     mountPoints            = local.mount_points
-    portMappings = var.port_mappings
-    memory       = var.container_memory
-    cpu          = var.container_cpu
+    portMappings           = var.port_mappings
+    memory                 = var.container_memory
+    cpu                    = var.container_cpu
   }
 
   container_definition_without_null = {
@@ -240,12 +241,12 @@ resource "aws_ecs_task_definition" "this" {
 
 # ECS service
 resource "aws_ecs_service" "this" {
-  name            = "${var.project-name}-ecs_service"
-  cluster         = aws_ecs_cluster.ecs-cluster.id
-  task_definition = aws_ecs_task_definition.this.arn
-  desired_count   = var.desired_count
-  iam_role        = data.aws_iam_role.ecs.arn
-  depends_on = [aws_iam_role_policy.this]
+  name                               = "${var.project-name}-ecs_service"
+  cluster                            = aws_ecs_cluster.ecs-cluster.id
+  task_definition                    = aws_ecs_task_definition.this.arn
+  desired_count                      = var.desired_count
+  iam_role                           = data.aws_iam_role.ecs.arn
+  depends_on                         = [aws_iam_role_policy.this]
   deployment_minimum_healthy_percent = 60
 
   # deployment_controller {

--- a/terraform/modules/ECS/outputs.tf
+++ b/terraform/modules/ECS/outputs.tf
@@ -1,5 +1,5 @@
 output "ecs-access-security-group" {
-  value = aws_security_group.ecs-access-security-group.id
+  value = aws_security_group.this.id
 }
 
 output "ecs_name" {

--- a/terraform/modules/ECS/variables.tf
+++ b/terraform/modules/ECS/variables.tf
@@ -16,7 +16,7 @@ variable "min-size" {
 
 variable "image_id" {
   type    = string
-  default = "ami-0b781a9543e01e880"
+  default = "ami-0a7c4f7f17d3eecbc"
 }
 
 variable "instance_type" {
@@ -54,7 +54,7 @@ variable "desired_count" {
 variable "container_port" {
   description = "The port value, already specified in the task definition, to be used for your service discovery service"
   type        = number
-  default     = 8080
+  default     = 80
 }
 
 variable "common_tags" {
@@ -132,4 +132,9 @@ variable "secrets" {
   }))
   description = "The secrets to pass to the container. This is a list of maps"
   default     = null
+}
+
+variable "instance_keypair" {
+  type    = string
+  default = null
 }

--- a/terraform/modules/ECS/variables.tf
+++ b/terraform/modules/ECS/variables.tf
@@ -11,7 +11,7 @@ variable "max-size" {
 variable "min-size" {
   description = "Minimum number of instances in the cluster"
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "image_id" {

--- a/terraform/modules/VPC-network/main.tf
+++ b/terraform/modules/VPC-network/main.tf
@@ -3,11 +3,11 @@
 resource "aws_vpc" "vpc" {
   cidr_block           = var.vpcCIDR
   instance_tenancy     = var.instanceTenancy[0]
-  enable_dns_support   = var.dnsSupport 
+  enable_dns_support   = var.dnsSupport
   enable_dns_hostnames = var.dnsHostNames
-    tags = {
-        Name = "${var.project-name}-vpc"
-    }
+  tags = {
+    Name = "${var.project-name}-vpc"
+  }
 }
 
 
@@ -22,46 +22,46 @@ data "aws_availability_zones" "available" {
 
 
 resource "aws_subnet" "subnet-public-1" {
-   	 vpc_id            = aws_vpc.vpc.id
-   	 cidr_block        = cidrsubnet(var.vpcCIDR, 8, 0)
-    	availability_zone = data.aws_availability_zones.available.names[0]
-	map_public_ip_on_launch = var.map_public_ip1
-    	tags = {
-       	Name = "${var.project-name}-subnet-public-1"
-       	Tier = "public"
-    	}
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(var.vpcCIDR, 8, 0)
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = var.map_public_ip1
+  tags = {
+    Name = "${var.project-name}-subnet-public-1"
+    Tier = "public"
+  }
 }
 
 resource "aws_subnet" "subnet-private-1" {
-   	 vpc_id            = aws_vpc.vpc.id
-    	cidr_block        = cidrsubnet(var.vpcCIDR, 8, 1)
-    	availability_zone = data.aws_availability_zones.available.names[0]
-    	tags = {
-       	Name = "${var.project-name}-subnet-private-1"
-       	Tier = "private"
-    	}
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(var.vpcCIDR, 8, 1)
+  availability_zone = data.aws_availability_zones.available.names[0]
+  tags = {
+    Name = "${var.project-name}-subnet-private-1"
+    Tier = "private"
+  }
 }
 
 resource "aws_subnet" "subnet-public-2" {
-    	vpc_id            = aws_vpc.vpc.id
-    	cidr_block        = cidrsubnet(var.vpcCIDR, 8, 2)
-    	availability_zone = data.aws_availability_zones.available.names[1]
-    	map_public_ip_on_launch = var.map_public_ip2
-    	tags = {
-       	Name = "${var.project-name}-subnet-public-2"
-       	Tier = "public"
-    	}
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(var.vpcCIDR, 8, 2)
+  availability_zone       = data.aws_availability_zones.available.names[1]
+  map_public_ip_on_launch = var.map_public_ip2
+  tags = {
+    Name = "${var.project-name}-subnet-public-2"
+    Tier = "public"
+  }
 }
 
 resource "aws_subnet" "subnet-private-2" {
-    vpc_id            = aws_vpc.vpc.id
-    cidr_block        = cidrsubnet(var.vpcCIDR, 8, 3)
-    availability_zone = data.aws_availability_zones.available.names[1]
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(var.vpcCIDR, 8, 3)
+  availability_zone = data.aws_availability_zones.available.names[1]
 
-    tags = {
-       Name = "${var.project-name}-subnet-private-2"
-       Tier = "private"
-    }
+  tags = {
+    Name = "${var.project-name}-subnet-private-2"
+    Tier = "private"
+  }
 }
 
 
@@ -70,30 +70,30 @@ resource "aws_subnet" "subnet-private-2" {
 # Internet Gateway
 # Internet Gateway in place
 resource "aws_internet_gateway" "IGW" {
-    vpc_id = aws_vpc.vpc.id
+  vpc_id = aws_vpc.vpc.id
 
-    tags = {
-       Name = "${var.project-name}-IGW"
-    }
+  tags = {
+    Name = "${var.project-name}-IGW"
+  }
 }
 
 
 
 # Elastic IP for NAT Gateway
 resource "aws_eip" "NAT-EIP" {
-	 vpc      = true
+  vpc = true
 }
 
 
 
 # NAT Gateway
 resource "aws_nat_gateway" "NAT-GW" {
-  count = var.deploy_nat ? 1 : 0	
+  count = var.deploy_nat ? 1 : 0
 
   allocation_id = aws_eip.NAT-EIP.id
   subnet_id     = aws_subnet.subnet-public-1.id
-  depends_on = [aws_internet_gateway.IGW]
-	tags = {
+  depends_on    = [aws_internet_gateway.IGW]
+  tags = {
     Name = "${var.project-name}-NAT-GW"
   }
 }

--- a/terraform/modules/VPC-network/nacl.tf
+++ b/terraform/modules/VPC-network/nacl.tf
@@ -1,120 +1,148 @@
 # Network ACL
 # 2 NACLs public/private (ALLOW ALL is not permitted)
 resource "aws_network_acl" "NACL-PUB" {
-	vpc_id = aws_vpc.vpc.id
-	subnet_ids = [aws_subnet.subnet-public-1.id,aws_subnet.subnet-public-2.id]
-	ingress {
-		protocol = "tcp"
-		rule_no = 100
-		action = "allow"
-		cidr_block = "0.0.0.0/0"
-		from_port = 80
-		to_port = 80
-		}
-	ingress {
-		protocol = "tcp"
-		rule_no = 110
-		action = "allow"
-		cidr_block = "0.0.0.0/0"
-		from_port = 443
-		to_port = 443
-		}
-  	egress {
-    		protocol   = -1
-    		rule_no    = 100
-    		action     = "allow"
-    		cidr_block = "0.0.0.0/0"
-    		from_port  = 0
-    		to_port    = 0
+  vpc_id     = aws_vpc.vpc.id
+  subnet_ids = [aws_subnet.subnet-public-1.id, aws_subnet.subnet-public-2.id]
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 80
+    to_port    = 80
   }
-	tags =	{	
-		Name = "${var.project-name}-NACL-PUB"
-		}
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 110
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+  # TODO: remove the following line
+  ingress {
+    protocol   = "-1"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+  tags = {
+    Name = "${var.project-name}-NACL-PUB"
+  }
 }
 resource "aws_network_acl" "NACL-PRI" {
-	vpc_id = aws_vpc.vpc.id
-	subnet_ids = [aws_subnet.subnet-private-1.id,aws_subnet.subnet-private-2.id]
-	ingress {
-		protocol = "tcp"
-		rule_no = 90
-		action = "allow"
-		cidr_block = var.vpcCIDR
-		from_port = 22
-		to_port = 22
-		}
-	ingress {
-		protocol = "tcp"
-		rule_no = 95
-		action = "allow"
-		cidr_block = cidrsubnet(var.vpcCIDR, 8, 1)
-		from_port = 3306
-		to_port = 3306
-		}
-	ingress {
-		protocol = "tcp"
-		rule_no = 96
-		action = "allow"
-		cidr_block = cidrsubnet(var.vpcCIDR, 8, 3)
-		from_port = 3306
-		to_port = 3306
-		}
-	ingress {
-		protocol = "tcp"
-		rule_no = 110
-		action = "allow"
-		cidr_block = var.vpcCIDR
-		from_port = 443
-		to_port = 443
-		}
-	ingress {
-		protocol = "tcp"
-		rule_no = 120
-		action = "deny"
-		cidr_block = "0.0.0.0/0"
-		from_port = 80
-		to_port = 80
-		}
-	ingress {
-		protocol = "tcp"
-		rule_no = 130
-		action = "deny"
-		cidr_block = "0.0.0.0/0"
-		from_port = 443
-		to_port = 443
-		}
-	egress {
-		protocol = "tcp"
-		rule_no = 95
-		action = "allow"
-		cidr_block = cidrsubnet(var.vpcCIDR, 8, 1)
-		from_port = 3306
-		to_port = 3306
-		}
-	egress {
-		protocol = "tcp"
-		rule_no = 96
-		action = "allow"
-		cidr_block = cidrsubnet(var.vpcCIDR, 8, 3)
-		from_port = 3306
-		to_port = 3306
-		}
-	egress {	
-		protocol = "tcp"
-		rule_no = 100
-		action = "allow"
-		cidr_block = "0.0.0.0/0"
-		from_port = 80
-		to_port = 80
-		}
-	egress {
-		protocol = "tcp"
-		rule_no = 110
-		action = "allow"
-		cidr_block = "0.0.0.0/0"
-		from_port = 443
-		to_port = 443
-		}
-	tags =	{	
-		Name = "${var.project-name}-NACL-PRI"
-		}
+  vpc_id     = aws_vpc.vpc.id
+  subnet_ids = [aws_subnet.subnet-private-1.id, aws_subnet.subnet-private-2.id]
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 90
+    action     = "allow"
+    cidr_block = var.vpcCIDR
+    from_port  = 22
+    to_port    = 22
+  }
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 95
+    action     = "allow"
+    cidr_block = cidrsubnet(var.vpcCIDR, 8, 1)
+    from_port  = 3306
+    to_port    = 3306
+  }
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 96
+    action     = "allow"
+    cidr_block = cidrsubnet(var.vpcCIDR, 8, 3)
+    from_port  = 3306
+    to_port    = 3306
+  }
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 110
+    action     = "allow"
+    cidr_block = var.vpcCIDR
+    from_port  = 443
+    to_port    = 443
+  }
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 120
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 80
+    to_port    = 80
+  }
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 130
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+  egress {
+    protocol   = "tcp"
+    rule_no    = 95
+    action     = "allow"
+    cidr_block = cidrsubnet(var.vpcCIDR, 8, 1)
+    from_port  = 3306
+    to_port    = 3306
+  }
+  egress {
+    protocol   = "tcp"
+    rule_no    = 96
+    action     = "allow"
+    cidr_block = cidrsubnet(var.vpcCIDR, 8, 3)
+    from_port  = 3306
+    to_port    = 3306
+  }
+  egress {
+    protocol   = "tcp"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 80
+    to_port    = 80
+  }
+  egress {
+    protocol   = "tcp"
+    rule_no    = 110
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+
+  # TODO: remove the following line
+  ingress {
+    protocol   = "-1"
+    rule_no    = 50
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+  egress {
+    protocol   = "-1"
+    rule_no    = 50
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = {
+    Name = "${var.project-name}-NACL-PRI"
+  }
 }

--- a/terraform/modules/VPC-network/route-table.tf
+++ b/terraform/modules/VPC-network/route-table.tf
@@ -1,52 +1,52 @@
 # Route tables and assosications
 # public
 resource "aws_route_table" "route-table-PUB" {
-    vpc_id = aws_vpc.vpc.id
-    route {
-      cidr_block = "0.0.0.0/0"
-      gateway_id = aws_internet_gateway.IGW.id
-    }
-    tags = {
-	Name = "${var.project-name}-route-table-PUB"
-	}	
+  vpc_id = aws_vpc.vpc.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.IGW.id
+  }
+  tags = {
+    Name = "${var.project-name}-route-table-PUB"
+  }
 }
 # private
 resource "aws_route_table" "route-table-PRI" {
-    vpc_id = aws_vpc.vpc.id
+  vpc_id = aws_vpc.vpc.id
 
-    tags = {
-	Name = "${var.project-name}-route-table-PRI"
-	}
-		
+  tags = {
+    Name = "${var.project-name}-route-table-PRI"
+  }
+
 }
 
 resource "aws_route" "private-nat-route" {
-    count = length(aws_nat_gateway.NAT-GW)
-    route_table_id = aws_route_table.route-table-PRI.id
-    destination_cidr_block = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.NAT-GW[count.index].id
+  count                  = length(aws_nat_gateway.NAT-GW)
+  route_table_id         = aws_route_table.route-table-PRI.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.NAT-GW[count.index].id
 }
 
 # route table associations
 # public route tables
 resource "aws_route_table_association" "public-1" {
-    subnet_id = aws_subnet.subnet-public-1.id
-    route_table_id = aws_route_table.route-table-PUB.id
+  subnet_id      = aws_subnet.subnet-public-1.id
+  route_table_id = aws_route_table.route-table-PUB.id
 }
 
 resource "aws_route_table_association" "public-2" {
-    subnet_id = aws_subnet.subnet-public-2.id
-    route_table_id = aws_route_table.route-table-PUB.id
+  subnet_id      = aws_subnet.subnet-public-2.id
+  route_table_id = aws_route_table.route-table-PUB.id
 }
 
 # private route tables
 resource "aws_route_table_association" "private-1" {
-    subnet_id = aws_subnet.subnet-private-1.id
-    route_table_id = aws_route_table.route-table-PRI.id
+  subnet_id      = aws_subnet.subnet-private-1.id
+  route_table_id = aws_route_table.route-table-PRI.id
 }
 
 resource "aws_route_table_association" "private-2" {
-    subnet_id = aws_subnet.subnet-private-1.id
-    route_table_id = aws_route_table.route-table-PRI.id
+  subnet_id      = aws_subnet.subnet-private-1.id
+  route_table_id = aws_route_table.route-table-PRI.id
 }
 

--- a/terraform/modules/VPC-network/route-table.tf
+++ b/terraform/modules/VPC-network/route-table.tf
@@ -21,7 +21,7 @@ resource "aws_route_table" "route-table-PRI" {
 }
 
 resource "aws_route" "private-nat-route" {
-  count = var.deploy_nat ? 1 : 0
+  count                  = var.deploy_nat ? 1 : 0
   route_table_id         = aws_route_table.route-table-PRI.id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.NAT-GW[count.index].id

--- a/terraform/modules/VPC-network/route-table.tf
+++ b/terraform/modules/VPC-network/route-table.tf
@@ -21,7 +21,7 @@ resource "aws_route_table" "route-table-PRI" {
 }
 
 resource "aws_route" "private-nat-route" {
-  count                  = length(aws_nat_gateway.NAT-GW)
+  count = var.deploy_nat ? 1 : 0
   route_table_id         = aws_route_table.route-table-PRI.id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.NAT-GW[count.index].id

--- a/terraform/modules/VPC-network/variables.tf
+++ b/terraform/modules/VPC-network/variables.tf
@@ -4,38 +4,38 @@ variable "project-name" {
 }
 
 variable "vpcCIDR" {
-    description = "VPC network"
-    default     = "192.168.0.0/16"
+  description = "VPC network"
+  default     = "192.168.0.0/16"
 }
 
 variable "instanceTenancy" {
-    type    = list(string)
-    description = "defult or dedicated"
-    default = ["default","dedicated"]
+  type        = list(string)
+  description = "defult or dedicated"
+  default     = ["default", "dedicated"]
 }
 
 variable "dnsSupport" {
-    type    = bool
-    default = true
-    
+  type    = bool
+  default = true
+
 }
 
 variable "dnsHostNames" {
-    type    = bool
-    default = true
+  type    = bool
+  default = true
 }
 
 variable "map_public_ip1" {
-    type    = bool
-    default = true
+  type    = bool
+  default = true
 }
 
 variable "map_public_ip2" {
-    type    = bool
-    default = true
+  type    = bool
+  default = true
 }
 
 variable "deploy_nat" {
-    type = bool
-    default = true
+  type    = bool
+  default = true
 }

--- a/terraform/modules/container_registry/main.tf
+++ b/terraform/modules/container_registry/main.tf
@@ -8,4 +8,8 @@ resource "aws_ecr_repository" "repo" {
   image_scanning_configuration {
     scan_on_push = true
   }
+
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
 }

--- a/terraform/modules/efs/main.tf
+++ b/terraform/modules/efs/main.tf
@@ -27,9 +27,9 @@ resource "aws_security_group" "efs_sg" {
   name   = "efs-sg"
 
   ingress {
-    protocol = "-1"
-    from_port = 0
-    to_port   = 0
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
     cidr_blocks = ["0.0.0.0/0"]
     # TODO: fix the security
     # from_port       = 2049
@@ -38,9 +38,9 @@ resource "aws_security_group" "efs_sg" {
   }
 
   egress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
     # TODO: fix the security
     # cidr_blocks = [var.cidr_block]

--- a/terraform/modules/efs/main.tf
+++ b/terraform/modules/efs/main.tf
@@ -27,18 +27,23 @@ resource "aws_security_group" "efs_sg" {
   name   = "efs-sg"
 
   ingress {
-    protocol        = "tcp"
-    from_port       = 2049
-    to_port         = 2049
-    security_groups = [var.ecs_sg_id]
+    protocol = "-1"
+    from_port = 0
+    to_port   = 0
+    cidr_blocks = ["0.0.0.0/0"]
+    # TODO: fix the security
+    # from_port       = 2049
+    # to_port         = 2049
+    # security_groups = [var.ecs_sg_id]
   }
 
   egress {
     from_port = 0
     to_port   = 0
     protocol  = "-1"
-
-    cidr_blocks = [var.cidr_block]
+    cidr_blocks = ["0.0.0.0/0"]
+    # TODO: fix the security
+    # cidr_blocks = [var.cidr_block]
   }
 }
 
@@ -46,6 +51,6 @@ resource "aws_security_group" "efs_sg" {
 resource "aws_efs_access_point" "wordpress" {
   file_system_id = aws_efs_file_system.efs_file.id
   root_directory {
-    path          = "/wordpress"
+    path = "/wordpress"
   }
 }

--- a/terraform/modules/efs/main.tf
+++ b/terraform/modules/efs/main.tf
@@ -51,6 +51,6 @@ resource "aws_security_group" "efs_sg" {
 resource "aws_efs_access_point" "wordpress" {
   file_system_id = aws_efs_file_system.efs_file.id
   root_directory {
-    path = "/wordpress"
+    path = "/"
   }
 }

--- a/terraform/modules/efs/variables.tf
+++ b/terraform/modules/efs/variables.tf
@@ -12,7 +12,7 @@ variable "vpc" {
 }
 variable "cidr_block" {
   description = "cidr_block for the EFS"
-  type          = string
+  type        = string
 }
 
 variable "ecs_sg_id" {

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,6 +1,6 @@
 output "github" {
   value = {
-    user   = aws_iam_access_key.github.user
-    id     = aws_iam_access_key.github.id
+    user = aws_iam_access_key.github.user
+    id   = aws_iam_access_key.github.id
   }
 }

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -25,7 +25,7 @@ resource "aws_lb_target_group" "this" {
   vpc_id   = var.vpc_id
   slow_start = 30
   health_check {
-    interval = 100 # was 300
+    interval = 120 # was 300
     healthy_threshold = 3
     timeout = 90 # was 120
     unhealthy_threshold = 5

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -23,6 +23,12 @@ resource "aws_lb_target_group" "this" {
   port     = local.targetPort
   protocol = local.targetProtocol
   vpc_id   = var.vpc_id
+  slow_start = 30
+  health_check {
+    healthy_threshold = 5
+    timeout = 15
+    unhealthy_threshold = 3
+  }
 }
 
 resource "aws_lb_listener" "this" {

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -25,9 +25,10 @@ resource "aws_lb_target_group" "this" {
   vpc_id   = var.vpc_id
   slow_start = 30
   health_check {
-    healthy_threshold = 5
-    timeout = 15
-    unhealthy_threshold = 3
+    interval = 100 # was 300
+    healthy_threshold = 3
+    timeout = 90 # was 120
+    unhealthy_threshold = 5
     matcher = "200-308"
   }
 }

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -19,17 +19,17 @@ resource "aws_lb" "this" {
 }
 # TODO: improve TG creation to use the same configuration for both TG chaging only the name basically
 resource "aws_lb_target_group" "this" {
-  name     = "${var.project}-lb-tg"
-  port     = local.targetPort
-  protocol = local.targetProtocol
-  vpc_id   = var.vpc_id
+  name       = "${var.project}-lb-tg"
+  port       = local.targetPort
+  protocol   = local.targetProtocol
+  vpc_id     = var.vpc_id
   slow_start = 30
   health_check {
-    interval = 120 # was 300
-    healthy_threshold = 3
-    timeout = 90 # was 120
+    interval            = 150
+    healthy_threshold   = 3
+    timeout             = 90
     unhealthy_threshold = 5
-    matcher = "200-308"
+    matcher             = "200-308"
   }
 }
 
@@ -67,10 +67,10 @@ resource "aws_security_group" "allow_web" {
   }
 }
 
-resource "aws_lb_target_group" "green" {
-  name        = "green"
-  vpc_id      = var.vpc_id
-  port        = local.targetPort
-  protocol    = "HTTP"
-  target_type = "ip"
-}
+# resource "aws_lb_target_group" "green" {
+#   name        = "green"
+#   vpc_id      = var.vpc_id
+#   port        = local.targetPort
+#   protocol    = "HTTP"
+#   target_type = "ip"
+# }

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -17,7 +17,7 @@ resource "aws_lb" "this" {
     Name = "${var.project}-lb"
   }
 }
-
+# TODO: improve TG creation to use the same configuration for both TG chaging only the name basically
 resource "aws_lb_target_group" "this" {
   name     = "${var.project}-lb-tg"
   port     = local.targetPort
@@ -28,6 +28,7 @@ resource "aws_lb_target_group" "this" {
     healthy_threshold = 5
     timeout = 15
     unhealthy_threshold = 3
+    matcher = "200-308"
   }
 }
 

--- a/terraform/modules/load_balancer/outputs.tf
+++ b/terraform/modules/load_balancer/outputs.tf
@@ -23,7 +23,7 @@ output "alb_target_group_name" {
   description = "The name of the Target Group."
 }
 
-output "alb_group_green_name" {
-  value       = aws_lb_target_group.green.name
-  description = "The name of the Target Group Green."
-}
+# output "alb_group_green_name" {
+#   value       = aws_lb_target_group.green.name
+#   description = "The name of the Target Group Green."
+# }

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -40,13 +40,13 @@ resource "aws_security_group" "da_rds_security_group" {
 // defining aurora
 // TODO: implement random passwords with SSM
 resource "aws_rds_cluster" "da-aurora-cluster" {
-  cluster_identifier      = "da-aurora-cluster"
-  engine                  = "aurora-mysql"
-  engine_version          = "5.7.mysql_aurora.2.07.1"
-  engine_mode             = "serverless"
+  cluster_identifier = "da-aurora-cluster"
+  engine             = "aurora-mysql"
+  engine_version     = "5.7.mysql_aurora.2.07.1"
+  engine_mode        = "serverless"
   # availability_zones      = ["ap-southeast-2"]
-  database_name           = aws_ssm_parameter.db_name.value #"mydb"
-  master_username         = aws_ssm_parameter.db_user.value  #"testuser"
+  database_name           = aws_ssm_parameter.db_name.value     #"mydb"
+  master_username         = aws_ssm_parameter.db_user.value     #"testuser"
   master_password         = aws_ssm_parameter.db_password.value #"test-password"
   backup_retention_period = 1
   vpc_security_group_ids  = [aws_security_group.da_rds_security_group.id]
@@ -84,7 +84,7 @@ resource "aws_ssm_parameter" "db_name" {
 }
 
 resource "aws_ssm_parameter" "db_user" {
-  name        = "WORDPRESS_DB_USERNAME"
+  name        = "WORDPRESS_DB_USER"
   description = "Database User Paramater"
   type        = "SecureString"
   value       = var.db_user

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,20 +1,20 @@
 output "secrets" {
-    value = {
-        db_host = {
-            name = aws_ssm_parameter.db_host.name
-            arn = aws_ssm_parameter.db_host.arn
-        }
-        db_name = {
-            name = aws_ssm_parameter.db_name.name
-            arn = aws_ssm_parameter.db_name.arn
-        }
-        db_user = {
-            name = aws_ssm_parameter.db_user.name
-            arn = aws_ssm_parameter.db_user.arn
-        }
-        db_password = {
-            name = aws_ssm_parameter.db_password.name
-            arn = aws_ssm_parameter.db_password.arn
-        }
+  value = {
+    db_host = {
+      name = aws_ssm_parameter.db_host.name
+      arn  = aws_ssm_parameter.db_host.arn
     }
+    db_name = {
+      name = aws_ssm_parameter.db_name.name
+      arn  = aws_ssm_parameter.db_name.arn
+    }
+    db_user = {
+      name = aws_ssm_parameter.db_user.name
+      arn  = aws_ssm_parameter.db_user.arn
+    }
+    db_password = {
+      name = aws_ssm_parameter.db_password.name
+      arn  = aws_ssm_parameter.db_password.arn
+    }
+  }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,9 +2,9 @@ output "vpc-module" {
   value = module.vpc
 }
 
-# output "lb-module" {
-#   value = module.load_balancer
-# }
+output "lb-module" {
+  value = module.load_balancer
+}
 
 output "ecr-module" {
   value = module.container_registry

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,3 +50,8 @@ variable "mount_points" {
   description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional."
   default     = []
 }
+
+variable "instance_keypair" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
This PR contains some fixes with the module integration to make the project run as expected.

The following items will be modified in future updates:

- [ ] restrict the SG rules (I needed to relax all rules to ensure that works)
- [ ] restrict the NACL rules

**What have done so far:**

- [x] fix volume naming in `mount_points` vars.
  - I might need to pass it via parameter maybe.
- [x] fix iam role permission for `ecs-instance-role` to include `ecs-tasks.amazonaws.com`
- [x] use data resource to obtain the role `AWSServiceRoleForECS` to use in the ECS services
- [x] update aws role policy to include permission to get SSM parameters
- [x] replace `launch_configuration` for `launch_template`. It is easy to use and each change create a new version that doesn't affect the current instances until they are terminated
- [x] update the AMI image id, the previous one was an ARM image and the ASG was unable to startup containers with that image. Used a x84_x64 one.
- [x] update default `container_port` from `8080` to `80`
- [x] fix wordpress db user name from `WORDPRESS_DB_USERNAME` to `WORDPRESS_DB_USER`. _Wordpress docker image accepts `WORDPRESS_DB_USER`_
- [x] include a variable to pass the instance keypair for debugging/troubleshooting purposes. _I am using it as env variable `TF_VAR_instance_keypair` so I don't need to change the main.tfvars._
- [x] fix efs volume mounting issues: invalid directory, unnecessary transition encryption port
- [x] improve lb health check to avoid instance deregistration process to start due to status code 301. _**Wordpress redirects requests to the instance public IP to the LB DNS name with status code 301**_
- [x] create script to kick off the project (create docker image, apply all terraform)
- [x] add script to deploy new task definition using ECS rolling update
- [x] update health check timeouts to consider the service bootstrap when the infra is applied at first time.
- [x] include delete_on_termination flag for instances created using the launch template
- [x] refactor and tidy up the makefiles
- [x] integrate the code deploy for rolling updates


**How to run it?**

```bash
make kick-n-run 😎
```

> You might need to wait a few seconds until the ECS start up a new task with the WP container.


