### PR TITLE
Script documentation changes and some script/variables renaming/merging

### DIFF
--- a/.github/workflows/on-push-terraform.yml
+++ b/.github/workflows/on-push-terraform.yml
@@ -26,5 +26,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        run: make all
+        run: make tf-all
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ This cloud migration is designed to comply with the following requirements:
 * [Make](https://en.wikipedia.org/wiki/Make_(software)) - automation
 
 
-
-
 ## Documents Index
 
 * [Docker Wordpress - How to use](docs/docker-wordpress.md)
@@ -65,7 +63,7 @@ This cloud migration is designed to comply with the following requirements:
   * [ECS Cluster](terraform/modules/ECS/README.md)
   * [ECR - Container Registry](terraform/modules/container_registry/README.md)
   * [Load Balancer](terraform/modules/load_balancer/README.md)
-  * [RDS Database](terraform/modules/rds-aurora-database/README.md)
+  * [RDS Database](terraform/modules/rds/README.md)
   * [ECS Task and Service](terraform/modules/ECS/README.md)
   * [EFS](terraform/modules/efs/README.md)
 
@@ -73,9 +71,10 @@ This cloud migration is designed to comply with the following requirements:
 ## Getting Started
 
 ### Prerequisites
- * Create a Github account: https://github.com/join
 
-*  Create your AWS account: https://aws.amazon.com/free/start-your-free-trial/
+* Create a Github account: https://github.com/join
+
+* Create your AWS account: https://aws.amazon.com/free/start-your-free-trial/
 
 * Install AWS cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html
 
@@ -87,45 +86,97 @@ This cloud migration is designed to comply with the following requirements:
 
 ## Usage
 
-<strong> Clone or download the repository to your machine: </strong>
-```
+> 🔥🔥🔥 **TL;DR;** 🔥🔥🔥<br />
+> GRAB THE POPCORN 🍿 <br />
+> RUN **`make kick-n-run` (docker daemon must be running)**<br />
+> ENJOY THE SHOW 😎 🎦 
 
+**Clone or download the repository to your machine:**
+
+```bash
 git clone https://github.com/devopsacademyau/2020-jun-project1-group1.git
+```
 
-```
-<strong> Set up your AWS credentials: </strong> 
-```
+**Set up your AWS credentials:** 
+
+```bash
 aws configure
 ```
 
- <strong> Decide on where you want the terraform state files to be stored. local is fine, but s3 is recommened (https://www.terraform.io/docs/backends/types/s3.html) </strong> 
-```
+ **Decide on where you want the terraform state files to be stored. local is fine, but s3 is recommened (https://www.terraform.io/docs/backends/types/s3.html)** 
+
+```bash
 vim ./terraform/_backend.tf
 ```
 
- <strong> Review and update the main.tfvars file with your variables  </strong> 
-```
+ **Review and update the main.tfvars file with your variables**
+
+```bash
 vim ./terraform/main.tfvars
 ```
-<strong> (Optional) plan the terraform build </strong>
 
-```
+**(Optional) plan the terraform build**
+
+```bash
 make tf-ci-plan
 ```
-<strong> Run below from your root directory </strong>
 
-```
+**Run below from your root directory**
+
+```bash
 make kick-n-run
 ```
-<strong>  Destroy the infrastructure </strong>
+
+**Destroy the infrastructure**
+
 ```
 make tf-ci-remove
 ```
+
+<!-- HOW TO'S -->
+
+## How To's
+
+### Initiate the infrastructure
+
+- Run [`make tf-all`](docs/scripts.md#tf-all)
+
+> it will create the infrastructure commands only, it will not push the wordpress docker image.
+
+***Quickest way:***
+
+- Run [`make kick-n-run`](docs/scripts.md#kick-n-run)
+
+## Update the docker image in the ECR
+
+- Run [`make update-wp`](docs/scripts.md#update-wp)
+
+### Deploy a new docker image to the ECS
+
+- Run [`make deploy-wp`](docs/scripts.md#deploy-wp)
+
+### Remove the resources created
+
+- Run [`make tf-ci-remove`](docs/scripts.md#tf-ci-remove)
+
+### Change the name of the project
+
+- Edit [main.tfvars](terraform/main.tfvars) file and change the variable `project`.
+- Edit `.env` file in the root directory (create if doens't exists) and change the variable `PROJECT_NAME`
+
+### Change the name of the ECR repository
+
+- Edit [main.tfvars](terraform/main.tfvars) and change the variable `repository_name`.
+- Edit `.env` file in the root directory (create if doens't exists) and change the variable `DOCKER_REPOSITORY`
+
+### Change the ECR repository location to another AWS account
+
+- Edit `.env` file in the root directory (create if doens't exists) and change the variable `DOCKER_REGISTRY_URL`
+
 <!-- ROADMAP -->
 ## Roadmap
 
 See the [open issues](https://github.com/devopsacademyau/2020-jun-project1-group1/issues) for a list of proposed features (and known issues).
-
 
 
 <!-- CONTRIBUTING -->
@@ -140,13 +191,10 @@ Contributions are what make the open source community such an amazing place to b
 5. Open a Pull Request
 
 
-
 <!-- LICENSE -->
 ## License
 
 Distributed under the Creative Commons Public Licenses. See `LICENSE` for more information.
-
-
 
 <!-- CONTACT -->
 ## Contact

--- a/README.md
+++ b/README.md
@@ -9,18 +9,29 @@
 <!-- TABLE OF CONTENTS -->
 ## Table of Contents
 
-* [About the Project](#about-the-project)
-  * [Solution Diagram](#solution-diagram)
-  * [Technologies](#technologies)
-* [Documents](#documents-index)
+<!-- Start Document Outline -->
+
+* [About The Project](#about-the-project)
+	* [Solution Diagram](#solution-diagram)
+	* [Technologies](#technologies)
+* [Documents Index](#documents-index)
 * [Getting Started](#getting-started)
-  * [Prerequisites](#prerequisites)
-  * [Installation](#installation)
+	* [Prerequisites](#prerequisites)
 * [Usage](#usage)
+* [How To's](#how-tos)
+	* [Initiate the infrastructure](#initiate-the-infrastructure)
+	* [Update the docker image in the ECR](#update-the-docker-image-in-the-ecr)
+	* [Deploy a new docker image to the ECS](#deploy-a-new-docker-image-to-the-ecs)
+	* [Remove the resources created](#remove-the-resources-created)
+	* [Change the name of the project](#change-the-name-of-the-project)
+	* [Change the name of the ECR repository](#change-the-name-of-the-ecr-repository)
+	* [Change the ECR repository location to another AWS account](#change-the-ecr-repository-location-to-another-aws-account)
 * [Roadmap](#roadmap)
 * [Contributing](#contributing)
 * [License](#license)
 * [Contact](#contact)
+
+<!-- End Document Outline -->
 
 
 ## About The Project
@@ -147,7 +158,7 @@ make tf-ci-remove
 
 - Run [`make kick-n-run`](docs/scripts.md#kick-n-run)
 
-## Update the docker image in the ECR
+### Update the docker image in the ECR
 
 - Run [`make update-wp`](docs/scripts.md#update-wp)
 
@@ -213,4 +224,3 @@ TBC
 [issues-url]: https://github.com/devopsacademyau/2020-jun-project1-group1/issues
 [license-shield]: https://img.shields.io/github/license/devopsacademyau/2020-jun-project1-group1.svg?style=flat-square
 [license-url]: https://github.com/devopsacademyau/2020-jun-project1-group1/blob/master/LICENSE
-

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,16 +1,89 @@
 # Introduction
 
+<!-- Start Document Outline -->
+
+* [Global](#global)
+	* [kick-n-run](#kick-n-run)
+	* [pull-required-images](#pull-required-images)
+	* [docs-terraform](#docs-terraform)
+* [Application: Docker/ECR](#application-dockerecr)
+	* [ecr-login](#ecr-login)
+	* [build-wp](#build-wp)
+	* [push-wp](#push-wp)
+	* [update-wp](#update-wp)
+	* [deploy-wp](#deploy-wp)
+* [Development: Github Actions](#development-github-actions)
+	* [ga-test-env-files](#ga-test-env-files)
+	* [ga-test-pr-build-wp](#ga-test-pr-build-wp)
+	* [ga-test-push-deploy-wp](#ga-test-push-deploy-wp)
+* [Infrastructure: Terraform](#infrastructure-terraform)
+	* [tf-ci-plan](#tf-ci-plan)
+	* [tf-ci-apply](#tf-ci-apply)
+	* [tf-ci-remove](#tf-ci-remove)
+	* [tf-all](#tf-all)
+* [AWS](#aws)
+	* [aws-caller-identity](#aws-caller-identity)
+	* [wait-lb](#wait-lb)
+
+<!-- End Document Outline --> 
+
+# Global
+
+## kick-n-run
+
+Kick off the infrastructure and application projects in one command.
+
+This command will execute the following tasks sequentially:
+
+1. **Initialise** the terraform modules (`terraform init`)
+
+2. **Create** the **ECR container registry** for the docker image (`terraform apply -auto-approve -var-file=main.tfvars -target=module.container_registry`)
+
+3. **Build** a fresh copy of the wordpress image and **push** it to the ECR created in step 2. (`make update-wp`)
+
+4. **Create** the rest of the infrastructure modules
+
+5. **Wait until the Load Balancer** is provisioned and an extra time for the target group listeners to be ready. (`make wait-lb`)
+
+**Usage:**
+
+```bash
+make kick-n-run
+
+# accept the confirmation typing "y"
+```
+
+**Requirements:**
+
+- docker client
+
+## pull-required-images
+
+Check for the required images used during the other commands and pull them if they are not present.
+
+It checks first if the image is pulled or not, so it is safe to call it multiple times.
+
+Images pulled:
+
+- [amazon/aws-cli](https://hub.docker.com/r/amazon/aws-cli)
+- [hashicorp/terraform](https://hub.docker.com/r/hashicorp/terraform)
+- [stedolan/jq](https://hub.docker.com/r/stedolan/jq)
+
+**Usage:**
+
+```bash
+make pull-required-images
+```
+
 ## docs-terraform
 
-Usage:
+This script will generate the terraform module documentation based on your input/output variables.
 
-Go to the root directory and run:
+**Usage:**
 
 ```bash
 make docs-terraform
 ```
-
-This script will generate the terraform module documentation based on your input/output variables.
 
 It uses [terraform-docs](https://github.com/terraform-docs/terraform-docs) to read `.tf` files and generate the document.
 
@@ -32,7 +105,228 @@ sections:
     - requirements
 ```
 
-This script will:
+**This script will:**
 - format the document as `markdown document`
 - inject the content of `doc.md` into `README.md`
 - hide the sections: `providers` and `requirements`
+
+# Application: Docker/ECR
+
+## ecr-login
+
+Authenticate the docker client with the ECR registry.
+
+**Usage:**
+
+```bash
+make ecr-login
+```
+
+**Requirements:**
+
+- docker client
+
+**Environment variables**
+
+| Name                     | Description                              |
+|--------------------------|------------------------------------------|
+| **AWS_DEFAULT_REGION**  | the default aws region where the ECR is located. |
+| **DOCKER_REGISTRY_URL** | the repository url where the docker image is located <br /> Example: `AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com/REPOSITORY_NAME` |
+
+## build-wp
+
+Build a new docker image
+
+**Usage:**
+
+```bash
+make build-wp
+```
+
+**Requirements:**
+
+- docker client
+
+**Environment variables**
+
+| Name                   | Description                              |
+|------------------------|------------------------------------------|
+| **DOCKER_REPOSITORY** | the name of the repository used to retrieve the images pushed into the repository. |
+
+## push-wp
+
+Push the recent built image to the ECR repository.
+
+> It will authenticate with the ECR first before run this command: `make ecr-login`
+
+The image will be tagget using the `repo commit sha` and `latest` alias. It will also use the ECR repository prefix. For example:
+
+```
+097922957456.dkr.ecr.ap-southeast-2.amazonaws.com/devops-wp:6eb88c0
+```
+
+**Requirements:**
+
+- docker client
+
+**Environment variables:**
+
+| Name                     | Description                              |
+|--------------------------|------------------------------------------|
+| **DOCKER_REPOSITORY**   | the name of the repository used to retrieve the images pushed into the repository. |
+| **AWS_DEFAULT_REGION**  | the default aws region where the ECR is located. |
+| **DOCKER_REGISTRY_URL** | the repository url where the docker image is located <br /> Example: `AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com/REPOSITORY_NAME` |
+
+
+## update-wp
+
+Execute the commands in order:
+
+- [ecr-login](#ecr-login)
+- [build-wp](#build-wp)
+- [push-wp](#push-wp)
+
+## deploy-wp
+
+It will create a new ECS task definition and trigger the rolling update of the tasks.
+
+**Usage:**
+
+```bash
+# in the root directory
+make deploy-wp
+```
+
+**List of operations:**
+
+1. Fetch the latest task definition deployed into the ECS. So any update in the task definition url will be reused for the next deployment.
+2. Fetch the latest image deployed into the ECR Repository.
+3. Update the `task-definition.json` with the new image tag.
+4. Register the new task-definition with the ECS.
+5. Update the ECS service with the new task-definition revision and force the deploment of new tasks.
+
+**Requirements:**
+
+- docker client
+- AWS CLI
+- sed
+
+**Environment variables:**
+
+| Name                     | Description                              |
+|--------------------------|------------------------------------------|
+| **PROJECT_NAME** | the name of the project, used to locate the ECS service for the task definition registration. |
+| **DOCKER_REPOSITORY**   | the name of the repository used to retrieve the images pushed into the repository. |
+| **DOCKER_REGISTRY_URL** | the repository url where the docker image is located <br /> Example: `AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com/REPOSITORY_NAME` |
+
+# Infrastructure: Terraform
+
+## tf-ci-plan
+
+Initialise the terraform modules and execute the terraform plan.
+The plan will be output as `terraform-plan` inside the `terraform` folder.
+
+It will use the file `terraform/main.tfvars` for input variables.
+
+**Usage:**
+
+```bash
+make tf-ci-plan
+```
+
+**Requirements:**
+
+- docker client
+
+## tf-ci-apply
+
+Run terraform apply (with auto-approve) using the terraform plan file `terraform-plan`.
+
+It will use the file `terraform/main.tfvars` for input variables.
+
+**Usage:**
+
+```bash
+make tf-ci-apply
+```
+
+**Requirements:**
+
+- docker client
+
+## tf-ci-remove
+
+Run terraform destroy (with auto-approve) using the `terraform/main.tfvars` as input variables
+
+```bash
+make tf-ci-remove
+```
+
+**Requirements:**
+
+- docker client
+
+## tf-all
+
+Run [tf-ci-plan](#tf-ci-plan) and [tf-ci-apply](#tf-ci-apply)
+
+**Usage:**
+
+```bash
+make tf-all
+```
+
+# AWS
+
+## aws-caller-identity
+
+Check the identity of the AWS user profile. Used mostly for test/debugging purposes.
+
+**Usage:**
+
+```bash
+make aws-caller-identity
+```
+
+## wait-lb
+
+Wait until the Load Balancer is ready to receive requests.
+
+> 🧯 **TODO:**  change the code due to S3 state compatibility
+
+# Development: Github Actions
+
+## ga-test-env-files
+
+This command will check that the following files exists in `.github`:
+
+- **secrets:** key-value field with secrets
+- **.env:** key-value with list of environment variables
+
+> It will exit an error if those files do not exits.
+
+## ga-test-pr-build-wp
+
+Simulate github action execution when:
+
+- a `pull-request` to `merge` was created
+- changes were made in `docker` folder
+
+```bash
+make ga-test-pr-build-wp
+```
+
+**Workflow:** [on-pr-build-wp.yml](../.github/workflows/on-pr-build-wp.yml)
+
+## ga-test-push-deploy-wp
+
+Simulate github action execution when:
+
+- a `push` to `merge` was initiated
+- changes were made in `docker` folder
+
+```bash
+make ga-test-push-deploy-wp
+```
+
+**Workflow:** [on-push-deploy-wp.yml](../.github/workflows/on-push-deploy-wp.yml)

--- a/scripts/deploy-wp.sh
+++ b/scripts/deploy-wp.sh
@@ -6,8 +6,8 @@
 
 echo "Using Variables:"
 echo "PROJECT_NAME: ${PROJECT_NAME}"
-echo "DOCKER_REPOSITORY_URL: ${DOCKER_REPOSITORY_URL}"
-echo "DOCKER_REPOSITORY_NAME: ${DOCKER_REPOSITORY_NAME}"
+echo "DOCKER_REGISTRY_URL: ${DOCKER_REGISTRY_URL}"
+echo "DOCKER_REPOSITORY: ${DOCKER_REPOSITORY}"
 
 echo "Download last valid definition"
 
@@ -20,13 +20,13 @@ aws ecs describe-task-definition \
 echo "Getting latest image tag"
 
 IMAGE_TAG=$(aws ecr describe-images \
-    --repository-name ${DOCKER_REPOSITORY_NAME} \
+    --repository-name ${DOCKER_REPOSITORY} \
     --query 'reverse(sort_by(imageDetails,& imagePushedAt))[0].imageTags[?@!=`latest`]' \
     --output text)
 
 echo "updating task definition with new image url"
 
-sed -i "s|.*\"image\":.*|\"image\": \"$DOCKER_REPOSITORY_URL:$IMAGE_TAG\",|" task-definition.json
+sed -i "s|.*\"image\":.*|\"image\": \"${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY}:${IMAGE_TAG}\",|" task-definition.json
 
 echo "registering task definition"
 

--- a/terraform/_provider.tf
+++ b/terraform/_provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.0"
   region  = var.aws_region
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,7 +25,7 @@ module "load_balancer" {
 
 module "container_registry" {
   source          = "./modules/container_registry"
-  # repository_name = "devops-wp"
+  repository_name = var.repository_name
 }
 
 module "efs" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,3 +55,8 @@ variable "instance_keypair" {
   type    = string
   default = null
 }
+
+variable "repository_name" {
+  type    = string
+  default = "devops-wordpress"
+}


### PR DESCRIPTION
Hey guys, those are some updates in the documentation. This PR also includes some script renaming and merging.

- [x] include script.md describing all scripts available in the Makefile
- [x] rename `make all` to `make tf-all` for name convention.
- [x] include a command `pull-required-images` what will pull all required images used in the makefile
  - [x] add this command as required for: `kick-n-run` `wait-lb` `ecr-login`
- [x] drop `DOCKER_REPOSITORY_URL` and use the variable `DOCKER_REGISTRY_URL` which is the same for the other commands
- [x] create a **How To's** section with some common changes/operations that we can make in the project

And some overall code tidy up / organisation.
